### PR TITLE
support wayland and x11 EGL by use of versions

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,5 +13,21 @@
 
     "dependencies": {
         "derelict-util": "~>2.0.1"
-    }
+    },
+
+    "configurations": [
+        {
+            "name": "x11",
+            "platforms": ["linux"],
+            "versions": ["EglX11"]
+        },
+        {
+            "name": "wayland",
+            "platforms": ["linux"],
+            "versions": ["EglWayland"]
+        },
+        {
+            "name": "library"
+        }
+    ]
 }

--- a/source/derelict/gles/eglplatform.d
+++ b/source/derelict/gles/eglplatform.d
@@ -51,22 +51,22 @@ else static if( Derelict_OS_Android ) {
 else static if( Derelict_OS_Posix && !Derelict_OS_Mac ) {
     alias EGLint = int;
 
-    // static if( wayland ) {
-    // struct wl_display;
-    // struct wl_egl_pixmap;
-    // struct wl_egl_window;
+    // There are multiple bindings to X11, no need to give preference.
+    // Client code must cast to void*
+    version (EglWayland)
+    {
+        alias EGLNativeDisplayType = void*;     // wl_display*
+        alias EGLNativeWindowType = void*;      // wl_egl_window*
+        alias EGLNativePixmapType = void*;      // should not be used
+    }
 
-    // alias EGLNativeWindowType = wl_display*;
-    // alias EGLNativePixmapType = wl_egl_pixmap*;
-    // alias EGLNativeDisplayType = wl_egl_window*;
-    // } else {
-    // FIXME: Assume X for now.
-    struct Display;
-
-    alias EGLNativeWindowType = Display*;
-    alias EGLNativePixmapType = uint;
-    alias EGLNativeDisplayType = uint;
-    // }
+    version(EglX11)
+    {
+        alias EGLNativeDisplayType = void*;     // Display*
+        alias EGLNativeWindowType = uint;       // Window
+        alias EGLNativePixmapType = uint;       // Pixmap
+    }
 }
-else
+else {
     static assert( 0, "Need to implement EGL types for this operating system." );
+}


### PR DESCRIPTION
In addition, it is proposed to expose `void*` type and request client to cast.
Rationale:
This avoids to pull-in dependencies, which would be wrong IMO as there are multiple bindings to x11 and derelict should not prefer one above another. Besides, dependencies version clash is easy to generate.
Having opaque struct declarations is hurting more than helping because:
 - casting is needed anyway due to different packages
 - it brings name conflicts in client code

Tested example of derelict-gles client with EGL, GLES2 and wayland can be found here:
https://github.com/rtbo/wayland-d/blob/master/examples/egl_window/source/egl_window.d

With `dub`, selecting wayland or x11 is done by clients like this:
```json
	"subConfigurations": {
		"derelict-gles": "wayland"
	}
```
It defaults to `x11` on linux, and should be transparent on other platforms (though I did not test that).